### PR TITLE
docker: Add http proxy listeners on 8080, 8081, and katzensocks on 4242

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -88,12 +88,12 @@ $(docker_compose_yml): ../genconfig/main.go $(distro)_go_mod.stamp $(net_name)
 $(net_name)/running.stamp: $(net_name)
 	make $(make_args) start
 
-run: $(docker_compose_yml) $(net_name)/server.$(distro) $(net_name)/voting.$(distro)
+run: $(docker_compose_yml) $(net_name)/server.$(distro) $(net_name)/voting.$(distro) $(net_name)/http_proxy_client.$(distro) $(net_name)/katzensocks.$(distro)
 	-cd $(net_name) && touch running.stamp \
 	&& DOCKER_USER=${docker_user} $(docker_compose) up --remove-orphans
 	cd $(net_name) && rm -v running.stamp
 
-start: $(docker_compose_yml) $(net_name)/server.$(distro) $(net_name)/voting.$(distro)
+start: $(docker_compose_yml) $(net_name)/server.$(distro) $(net_name)/voting.$(distro) $(net_name)/http_proxy_client.$(distro) $(net_name)/katzensocks.$(distro)
 	cd $(net_name); DOCKER_USER=${docker_user} $(docker_compose) up --remove-orphans -d; $(docker_compose) top
 	touch $(net_name)/running.stamp
 
@@ -184,6 +184,16 @@ $(net_name)/ping.$(distro): $(distro)_go_mod.stamp $(net_name)
 		$(docker) run ${docker_args} $(mount_net_name) --rm katzenpost-$(distro)_go_mod \
 			$(sh) -c 'cd ping && go mod verify && go build -ldflags ${ldflags} && \
 			mv ping /$(net_name)/ping.$(distro)'
+
+$(net_name)/http_proxy_client.$(distro): $(distro)_go_mod.stamp $(net_name)
+		$(docker) run ${docker_args} $(mount_net_name) --rm katzenpost-$(distro)_go_mod \
+			$(sh) -c 'cd http/proxy && make $(make_args) clean client/client && \
+			mv client/client /$(net_name)/http_proxy_client.$(distro)'
+
+$(net_name)/katzensocks.$(distro): $(distro)_go_mod.stamp $(net_name)
+		$(docker) run ${docker_args} $(mount_net_name) --rm katzenpost-$(distro)_go_mod \
+			$(sh) -c 'cd katzensocks && make $(make_args) clean client/cmd/client/client && \
+			mv client/cmd/client/client /$(net_name)/katzensocks.$(distro)'
 
 clean-images: stop
 	@-for distro in $(DISTROS); do \

--- a/genconfig/main.go
+++ b/genconfig/main.go
@@ -694,5 +694,45 @@ services:
     network_mode: host
 `, authCfg.Server.Identifier, dockerImage, s.baseDir, s.baseDir, s.binSuffix, s.baseDir, authCfg.Server.Identifier)
 	}
+
+	// add a HTTP proxy to the Cashu mint for the proxy client
+	write(f, `
+  %s:
+    restart: "no"
+    image: %s
+    volumes:
+      - ./:%s
+    command: %s/http_proxy_client%s -cfg %s/client/client.toml -ep cashu -port 8080
+    network_mode: host
+    expose:
+     - "8080/tcp"
+`, "proxy_cashu_client", dockerImage, s.baseDir, s.baseDir, s.binSuffix, s.baseDir)
+
+	// add a HTTP proxy to the Cashu mint for the proxy service
+	write(f, `
+  %s:
+    restart: "no"
+    image: %s
+    volumes:
+      - ./:%s
+    command: %s/http_proxy_client%s -cfg %s/client/client.toml -ep cashu -port 8081
+    network_mode: host
+    expose:
+     - "8081/tcp"
+`, "proxy_cashu_server", dockerImage, s.baseDir, s.baseDir, s.binSuffix, s.baseDir)
+
+	// add katzensocks proxy client
+	write(f, `
+  %s:
+    restart: "no"
+    image: %s
+    volumes:
+      - ./:%s
+    command: %s/katzensocks%s -cfg %s/client/client.toml -port 4242
+    network_mode: host
+    expose:
+     - "4242/tcp"
+`, "katzensocks", dockerImage, s.baseDir, s.baseDir, s.binSuffix, s.baseDir)
+
 	return nil
 }


### PR DESCRIPTION
Adds local http proxies on ports 8080 and 8081 that route http requests via katzenpost to localhost:3338 Adds kateznsocks SOCKS5 proxy on port 4242

TODO: Add Cashu mint service on 3338