### PR TITLE
genconfig, docker: make listening address configurable

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -49,6 +49,7 @@ DISTROS=alpine debian
 distro=alpine
 net_name=voting_mixnet
 base_port=30000
+bind_addr=127.0.0.1
 docker_compose_yml=$(net_name)/docker-compose.yml
 sh=$(shell if echo ${distro}|grep -q alpine; then echo sh; else echo bash; fi)
 SHELL=/bin/bash
@@ -81,7 +82,7 @@ $(net_name):
 $(docker_compose_yml): ../genconfig/main.go $(distro)_go_mod.stamp $(net_name)
 	$(docker) run -e --network=host ${docker_args} --rm katzenpost-$(distro)_go_mod \
 		$(sh) -c 'cd genconfig && go build && cd ../docker \
-		&& ../genconfig/genconfig -nv ${auths} -n ${mixes} -p ${providers} \
+		&& ../genconfig/genconfig -a ${bind_addr} -nv ${auths} -n ${mixes} -p ${providers} \
 		-sr ${sr} -mu ${mu} -muMax ${muMax} -lP ${lP} -lPMax ${lPMax} -lL ${lL} \
 		-lLMax ${lLMax} -lD ${lD} -lDMax ${lDMax} -lM ${lM} -lMMax ${lMMax} \
 		-S .$(distro) -v -o ./$(net_name) -b /$(net_name) -P $(base_port) \


### PR DESCRIPTION
this adds bind_addr environment variable that will configure the listening address for the mix and authority nodes. you can use this to make a testnet reachable via the public internet for testing or demonstration purposes.